### PR TITLE
Enable Effort to work with EF model with function mappings for entity Insert/Update/Delete

### DIFF
--- a/Main/Source/Effort/Effort.csproj
+++ b/Main/Source/Effort/Effort.csproj
@@ -257,6 +257,7 @@
     <Compile Include="Internal\Common\TypeHelper.cs" />
     <Compile Include="EntityConnectionFactory.cs" />
     <Compile Include="Internal\StorageSchema\CommonPropertyElementModifier.cs" />
+    <Compile Include="Internal\StorageSchema\ModificationFunctionMappingModifier.cs" />
     <Compile Include="Internal\StorageSchema\ReturnTypeAttributeSelector.cs" />
     <Compile Include="Internal\StorageSchema\ProviderManifestTokenAttributeModifier.cs" />
     <Compile Include="Internal\StorageSchema\ProviderAttributeModifier.cs" />

--- a/Main/Source/Effort/Internal/Common/MetadataWorkspaceHelper.cs
+++ b/Main/Source/Effort/Internal/Common/MetadataWorkspaceHelper.cs
@@ -87,6 +87,11 @@ namespace Effort.Internal.Common
                 UniversalStorageSchemaModifier.Instance.Modify(ssdlFile, new ProviderInformation(providerInvariantName, providerManifestToken));
             }
 
+            foreach (var mslFile in msl)
+            {
+                new ModificationFunctionMappingModifier().Modify(mslFile, new Effort.Internal.Common.XmlProcessing.ModificationContext());
+            }
+
             MetadataWorkspace workspace = CreateMetadataWorkspace(csdl, ssdl, msl);
 
             return workspace;

--- a/Main/Source/Effort/Internal/StorageSchema/ModificationFunctionMappingModifier.cs
+++ b/Main/Source/Effort/Internal/StorageSchema/ModificationFunctionMappingModifier.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+using Effort.Internal.Common.XmlProcessing;
+
+namespace Effort.Internal.StorageSchema
+{
+    /// <summary>
+    /// Removes function mapping for Insert, Update, and Delete.
+    /// This is required for being able to save changes to EFFORT context
+    /// based on model with defined modification function mappings.
+    /// </summary>
+    internal class ModificationFunctionMappingModifier : IElementModifier
+    {
+        public void Modify(XElement element, IModificationContext context)
+        {
+            var functionMappings = element.Descendants(XName.Get("ModificationFunctionMapping", "http://schemas.microsoft.com/ado/2009/11/mapping/cs")).ToList();
+            foreach (var mappingElement in functionMappings)
+            {
+                mappingElement.Remove();
+            }
+        }
+    }
+}


### PR DESCRIPTION
I have EF model with stored procedures used to handle entity modifications through function mappings. This caused DbContext.SaveChanges() throwing exception in CommandActionFactory as commandTree was of type DbFunctionCommandTree which is not supported.

I have updated the process of metadata loading to remove information about function mappings. This causes saving changes to go through standard DbModificationCommandTree.

I understand that the result on actual database data can be different when calling a stored procedure compared to simple SQL Insert/Update/Delete statement. However, mocking the DbContext is still very useful and this is the closest I can get without having to mock actual stored procedures.
