### PR TITLE
Improve error message for missing EdmType

### DIFF
--- a/Main/Source/Effort.Shared/Provider/EffortProviderManifest.cs
+++ b/Main/Source/Effort.Shared/Provider/EffortProviderManifest.cs
@@ -96,7 +96,6 @@ namespace Effort.Provider
 
             // The primitive type name identifies the appropriate store type
 
-            //PrimitiveType storeType = this.StoreTypeNameToStorePrimitiveType[name];
             PrimitiveType storeType;
             if (!this.StoreTypeNameToStorePrimitiveType.TryGetValue(name, out storeType))
             {

--- a/Main/Source/Effort.Shared/Provider/EffortProviderManifest.cs
+++ b/Main/Source/Effort.Shared/Provider/EffortProviderManifest.cs
@@ -22,11 +22,10 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------
 
-using System.Collections.Generic;
-
 namespace Effort.Provider
 {
     using System;
+    using System.Collections.Generic;
 #if !EFOLD
     using System.Data.Entity.Core.Common;
     using System.Data.Entity.Core.Metadata.Edm;

--- a/Main/Source/Effort.Shared/Provider/EffortProviderManifest.cs
+++ b/Main/Source/Effort.Shared/Provider/EffortProviderManifest.cs
@@ -22,6 +22,8 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
+
 namespace Effort.Provider
 {
     using System;
@@ -94,8 +96,13 @@ namespace Effort.Provider
             string name = edmType.EdmType.Name.ToLowerInvariant();
 
             // The primitive type name identifies the appropriate store type
-            PrimitiveType storeType = this.StoreTypeNameToStorePrimitiveType[name];
 
+            //PrimitiveType storeType = this.StoreTypeNameToStorePrimitiveType[name];
+            PrimitiveType storeType;
+            if (!this.StoreTypeNameToStorePrimitiveType.TryGetValue(name, out storeType))
+            {
+                throw new KeyNotFoundException("Unable to find store type for edmType " + name + ", Effort does not support this data type.");
+            }
             return ConvertTypeUsage(edmType, storeType);
         }
 


### PR DESCRIPTION
Improve error message for unsupported types like geography.  Instead of getting a KeyNotFoundException with no idea why or what it was trying to find you will get this error instead: "Unable to find store type for edmType geography, Effort does not support this data type."