### PR TITLE
Allow relative path in FileLoader

### DIFF
--- a/Main/Source/Effort.Shared/DataLoaders/FileSource.cs
+++ b/Main/Source/Effort.Shared/DataLoaders/FileSource.cs
@@ -91,7 +91,12 @@ namespace Effort.DataLoaders
 
             if (uri == null)
             {
-                return new InvalidFileProvider();
+                //Try current directory + path
+                Uri.TryCreate(System.IO.Path.Combine(Environment.CurrentDirectory, path), UriKind.Absolute, out uri);
+                if (uri == null)
+                {
+                    return new InvalidFileProvider();
+                }
             }
 
             switch (uri.Scheme)


### PR DESCRIPTION
Hi,
I made a change in FileLoader.cs to allow loading of csv files from relative path.
For instance, I have a test suite that copies the folder containing the csv files in bin directory. With this change someone could do:

IDataLoader loader = new Effort.DataLoaders.CsvDataLoader("csvs_folder_in_bin_without_c_bla_bla_bla");
