### PR TITLE
feat: add schema to filename export

### DIFF
--- a/Main/Source/Effort.CsvTool/ViewModels/MainViewModel.cs
+++ b/Main/Source/Effort.CsvTool/ViewModels/MainViewModel.cs
@@ -212,7 +212,7 @@ namespace Effort.CsvTool.ViewModels
                             cmd.CommandText = string.Format("SELECT * FROM [{0}].[{1}]", schemaName, name);
                             cmd.CommandType = CommandType.Text;
 
-                            FileInfo file = new FileInfo(Path.Combine(dir.FullName, string.Format("{0}.csv", name)));
+                            FileInfo file = new FileInfo(Path.Combine(dir.FullName, string.Format("{0}.{1}.csv", schemaName, name)));
 
                             if (!dir.Exists)
                             {


### PR DESCRIPTION
When exporting a database to csv, the files that are created don't include the schema in the filename. 
If there are multiple tables with the same names in different schemas, only the last table's file remain after the export.

close: #166 
